### PR TITLE
feat: add snowflake style variations

### DIFF
--- a/effect.html
+++ b/effect.html
@@ -230,6 +230,7 @@
       const speed=document.getElementById('speed');
       const fxSnow=document.getElementById('fxSnow');
       const btnClearSnow=document.getElementById('btnClearSnow');
+      const snowStyle=document.getElementById('snowStyle');
 
       let img=new Image();
       let flakes=[];
@@ -248,18 +249,60 @@
           x:Math.random()*canvas.width,
           y:Math.random()*canvas.height,
           r:Math.random()*size/2+1,
-          v:Math.random()*spd+0.5
+          v:Math.random()*spd+0.5,
+          angle:Math.random()*Math.PI*2
         }));
+      }
+
+      function drawFlake(f){
+        ctx.save();
+        ctx.translate(f.x,f.y);
+        ctx.rotate(f.angle);
+        const style=snowStyle.value;
+        if(style==='line'){
+          ctx.strokeStyle='#fff';
+          ctx.lineWidth=1;
+          for(let i=0;i<6;i++){
+            ctx.beginPath();
+            ctx.moveTo(0,0);
+            ctx.lineTo(0,f.r*2);
+            ctx.stroke();
+            ctx.rotate(Math.PI/3);
+          }
+        }else if(style==='solid'){
+          ctx.fillStyle='#fff';
+          ctx.beginPath();
+          for(let i=0;i<8;i++){
+            const ang=i*Math.PI/4;
+            const rad=i%2===0?f.r:f.r/2;
+            ctx.lineTo(Math.cos(ang)*rad,Math.sin(ang)*rad);
+          }
+          ctx.closePath();
+          ctx.fill();
+        }else if(style==='star'){
+          ctx.fillStyle='#fff';
+          ctx.beginPath();
+          for(let i=0;i<10;i++){
+            const ang=i*Math.PI/5;
+            const rad=i%2===0?f.r:f.r/2;
+            ctx.lineTo(Math.cos(ang)*rad,Math.sin(ang)*rad);
+          }
+          ctx.closePath();
+          ctx.fill();
+        }else{
+          ctx.fillStyle='#fff';
+          ctx.beginPath();
+          ctx.arc(0,0,f.r,0,Math.PI*2);
+          ctx.fill();
+        }
+        ctx.restore();
       }
 
       function render(){
         drawImage();
         if(fxSnow.checked){
-          ctx.fillStyle='#fff';
           flakes.forEach(f=>{
-            ctx.beginPath();
-            ctx.arc(f.x,f.y,f.r,0,Math.PI*2);
-            ctx.fill();
+            drawFlake(f);
             f.y+=f.v;
             if(f.y>canvas.height){f.y=-f.r;f.x=Math.random()*canvas.width;}
           });
@@ -270,6 +313,7 @@
       density.addEventListener('input',initFlakes);
       flakeSize.addEventListener('input',initFlakes);
       speed.addEventListener('input',initFlakes);
+      snowStyle.addEventListener('change',initFlakes);
       btnClearSnow.addEventListener('click',initFlakes);
 
       fileInput.addEventListener('change',e=>{


### PR DESCRIPTION
## Summary
- allow selecting different snowflake styles: line, solid star, cartoon star
- render snowflakes with random orientation and style-specific shapes

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fb0617988324b10252b07658f19b